### PR TITLE
FOQUS Cloud Simulation SignedURLs 

### DIFF
--- a/turbine/commands/__init__.py
+++ b/turbine/commands/__init__.py
@@ -424,6 +424,7 @@ def post_page_by_url(url, configFile, section, data, headers={}, **kw):
     subr = kw.get('subresource')
     if subr is not None:
         url = '/'.join([url.strip('/'),subr])
+    _log.getLogger(__name__).info('post_page_by_url: url="%s"',  url)
     d = _urlopen(url, data, headers=headers)
     _log.getLogger(__name__).info("HTTP POST(%d): %s", d.code, url)
     _log.getLogger(__name__).debug("BODY:\n%s", data)

--- a/turbine/commands/__init__.py
+++ b/turbine/commands/__init__.py
@@ -395,6 +395,8 @@ def _put_page_by_url(url, configFile, section, data, content_type='application/o
     if subr is not None:
         url = '/'.join([url.strip('/'),subr])
 
+    ## AWS: Get Signed URL and PUT
+
     data = _encode_codec(data, content_type)
     request = urllib.request.Request(url, data=data)
     request.add_header('Content-Type', content_type)

--- a/turbine/commands/__init__.py
+++ b/turbine/commands/__init__.py
@@ -379,6 +379,7 @@ def _decode_codec(data, content_type):
             codec_name = 'latin-1'
         else:
             codec_name = 'utf-8'
+        _log.getLogger(__name__).debug("Type: %s", type(data))
         return data.decode(codec_name)
     _log.getLogger(__name__).error("Bad Data Type %s", type(data))
     raise RuntimeError("Bad Data Type %s" % type(data))

--- a/turbine/commands/__init__.py
+++ b/turbine/commands/__init__.py
@@ -56,7 +56,7 @@ def _print_numbered_lines(data, out=sys.stdout):
         print('%d) %s' % (i, data[i]), file=out)
 
 
-def _print_as_json(data, out=sys.stdout):
+def _print_as_json(data, out=sys.stdout, **kw):
     print(json.dumps(data), file=out)
 
 
@@ -456,6 +456,7 @@ def get_page_by_url(url, configFile, **extra_query):
 
 def get_page(configFile, section, **extra_query):
     url = configFile.get(section, 'url')
+    _log.getLogger(__name__).debug('get_page url: "%s"', url)
     content = get_page_by_url(url, configFile, **extra_query)
     return content
 

--- a/turbine/commands/requests_base.py
+++ b/turbine/commands/requests_base.py
@@ -92,7 +92,11 @@ def put_page(configFile, section, data, **kw):
     """
     url,auth,params = read_configuration(configFile,section,**kw)
     signed_url = params.get('SignedUrl', False)
-    if signed_url is True:
+    if url.split('/')[-2] == 'simulation':
+        logging.getLogger(__name__).debug('upload simulation meta data')
+        if 'SignedUrl' in params:
+            del params['SignedUrl']
+    elif signed_url is True:
         #logging.getLogger(__name__).debug('put_page signed_url: "%s" "%s"', url, str(params))
         r = _put_page(url, auth, data='', allow_redirects=False, **params)
         assert r.status_code == 302, "HTTP Status Code %d" %r.status_code
@@ -105,7 +109,7 @@ def put_page(configFile, section, data, **kw):
     #    return r.raw
     logging.getLogger(__name__).debug('HTTP PUT(%s)', r.status_code)
     if r.status_code != 200:
-        logging.getLogger(__name__).error('upload failed: %s' str(r.__dict__))
+        logging.getLogger(__name__).error('upload failed: %s' %str(r.__dict__))
         raise RuntimeError("HTTP PUT(%s) failure for %s" %(r.status_code,url))
     return r.text
 

--- a/turbine/commands/requests_base.py
+++ b/turbine/commands/requests_base.py
@@ -1,0 +1,96 @@
+"""
+requests_base:  'requests' module drop in replacement
+
+Joshua R. Boverhof, LBNL
+See LICENSE.md for copyright notice!
+"""
+import os,logging,requests,configparser
+from requests.exceptions import RequestException, HTTPError, ConnectionError
+
+#def standard_options(url, options, **extra_query):
+def read_configuration(configFile, section, **kw):
+    """
+    http query parameters (kw):
+        page
+        rpp
+        SignedUrl
+    """
+    assert type(configFile) is configparser.ConfigParser
+    assert type(kw.get('SignedUrl', False)) is bool
+    params = {}
+    url = configFile.get(section, 'url')
+    for k,v in kw.items():
+        if k == 'subresource' and v:
+            url = '/'.join([url.strip('/'),v])
+        elif callable(v):
+            params[k] = v()
+        else:
+            params[k] = v
+    signed_url = params.get('SignedUrl', False)
+    assert type(signed_url) is bool
+    verbose =  params.get('verbose', False)
+    assert type(verbose) is bool
+    rpp =  params.get('rpp', '0')
+    assert type(int(rpp)) is int
+    pagenum = params.get('page', '0')
+    assert type(int(pagenum)) is int
+    auth = (configFile.get('Authentication', 'username', raw=True),
+        configFile.get('Authentication', 'password', raw=True))
+    return (url, auth, params)
+
+def delete_page(configFile, section, **kw):
+    url,auth,params = read_configuration(configFile,section,**kw)
+    return _delete_page(url, auth, **params).text
+
+def _delete_page(url, auth, **params):
+    """
+    parameters:
+        auth --- username and password tuple
+    keyword params
+        -- SignedUrl, service will return signed S3 URL and it Will
+        automatically be followed.
+    """
+    assert type(auth) is tuple
+    logging.getLogger(__name__).debug('_delete_page url: "%s"', url)
+    return requests.delete(url, params=params, auth=auth)
+
+def get_page(configFile, section, **kw):
+    url,auth,params = read_configuration(configFile,section,**kw)
+    r = _get_page(url, auth, **params)
+    return r.text
+
+def _get_page(url, auth, **params):
+    """
+    parameters:
+        auth --- username and password tuple
+    keyword params
+        -- SignedUrl, service will return signed S3 URL and it Will
+        automatically be followed.
+    """
+    assert type(auth) is tuple
+    logging.getLogger(__name__).debug('_get_page url: "%s"', url)
+    return requests.get(url, params=params, auth=auth)
+
+def put_page(configFile, section, data, **kw):
+    url,auth,params = read_configuration(configFile,section,**kw)
+    signed_url = params.get('SignedUrl', False)
+    if signed_url is True:
+        logging.getLogger(__name__).debug('put_page signed_url: "%s"', url)
+        r = _put_page(url, auth, data='', allow_redirects=False, **params)
+        assert r.status_code == 302
+        url = r.headers.get('Location')
+        auth = None
+        del params['SignedUrl']
+    return _put_page(url, auth, data, **params)
+
+def _put_page(url, auth, **params):
+    """
+    parameters:
+        auth --- username and password tuple
+    keyword params
+        -- SignedUrl, service will return signed S3 URL and it Will
+        automatically be followed.
+    """
+    assert type(auth) is tuple
+    logging.getLogger(__name__).debug('_put_page url: "%s"', url)
+    return requests.get(url, params=params, auth=auth)

--- a/turbine/commands/turbine_application_script.py
+++ b/turbine/commands/turbine_application_script.py
@@ -61,7 +61,7 @@ def main_list(args=None, func=_print_list):
     content = get_page(configFile, SECTION, **query)
     data = load_pages_json([content])
     if func:
-        func(data, options.verbose)
+        func(data, verbose=options.verbose)
     return data
 
 

--- a/turbine/commands/turbine_session_script.py
+++ b/turbine/commands/turbine_session_script.py
@@ -147,7 +147,12 @@ def main_create_jobs(args=None, func=_print_page):
 
     log = _log.getLogger(__name__)
     log.debug("main_create_jobs")
-    input_data = json.loads(open(jobs_file).read())
+
+    try:
+        with open(jobs_file) as fd:
+            input_data = json.load(fd)
+    except FileNotFoundError:
+        input_data = json.loads(jobs_file)
 
     assert(type(input_data) is list)
 
@@ -274,7 +279,7 @@ def main_start_jobs(args=None, func=_print_page):
 
     _log.getLogger(__name__).debug("main_start_jobs")
     page = start_jobs(configFile, sessionid)
-    data = int(page)
+    data = json.loads(page)
     if func:
         func(data)
     return data

--- a/turbine/commands/turbine_simulation_script.py
+++ b/turbine/commands/turbine_simulation_script.py
@@ -16,20 +16,21 @@ import sys
 import os
 import json
 import uuid
-import logging as _log
+import logging
 import optparse
 from urllib.error import HTTPError
 from turbine.commands import add_options, add_json_option, get_page, get_paging, put_page, post_page,\
     _open_config, load_pages_json, delete_page, _print_page
 
 SECTION = "Simulation"
-
+_log = logging.getLogger(__name__)
 
 def _print_json(data, verbose=False, out=sys.stdout):
     if type(data) in (list, dict):
         json.dump(data, out)
     else:
-        print(data, end="", file=out)
+        _log.debug("_print_json (%d): %s" %(len(data), type(data)))
+        print(data.encode('latin-1'), end="", file=out)
 
 
 def _print_simulation_list(all, verbose=False, out=sys.stdout):
@@ -108,8 +109,7 @@ def main_update(args=None):
     if len(args) != 3:
         op.error('expecting 3 arguments')
 
-    log = _log.getLogger('%s.main_update' % __name__)
-    log.debug(args)
+    _log.debug(args)
 
     file_name = args[1]
     if not os.path.isfile(file_name):
@@ -228,15 +228,13 @@ def main_delete(args=None, func=_print_page):
     except Exception as ex:
         op.error(ex)
 
-    log = _log.getLogger(__name__)
-
     try:
         page = delete_page(configFile, SECTION,
                            subresource='%s' % simulationName)
     except HTTPError as ex:
-        log.error(ex)
+        _log.error(ex)
         raise
-    log.debug("PAGE: %s" % page)
+    _log.debug("PAGE: %s" % page)
 
     return page
 

--- a/turbine/commands/turbine_simulation_script.py
+++ b/turbine/commands/turbine_simulation_script.py
@@ -18,9 +18,9 @@ import json
 import uuid
 import logging
 import optparse
-from urllib.error import HTTPError
-from turbine.commands import add_options, add_json_option, get_page, get_paging, put_page, post_page,\
-    _open_config, load_pages_json, delete_page, _print_page
+from .requests_base import get_page, put_page, delete_page
+from . import add_options, add_json_option,\
+    _open_config, load_pages_json, _print_page
 
 SECTION = "Simulation"
 _log = logging.getLogger(__name__)
@@ -29,8 +29,7 @@ def _print_json(data, verbose=False, out=sys.stdout):
     if type(data) in (list, dict):
         json.dump(data, out)
     else:
-        _log.debug("_print_json (%d): %s" %(len(data), type(data)))
-        print(data.encode('latin-1'), end="", file=out)
+        print(data, file=out)
 
 
 def _print_simulation_list(all, verbose=False, out=sys.stdout):
@@ -84,7 +83,7 @@ def main_create(args=None):
     try:
         data = put_page(cp, SECTION, data,
                         content_type='application/json', **kw)
-    except HTTPError as ex:
+    except urllib.error.HTTPError as ex:
         _log.error(ex)
         if hasattr(ex, 'readlines'):
             _log.error("".join(ex.readlines()))
@@ -129,7 +128,7 @@ def main_update(args=None):
         contents = fd.read()
         try:
             data = put_page(configFile, SECTION, contents, **kw)
-        except HTTPError as ex:
+        except urllib.error.HTTPError as ex:
             _log.error("HTTP Code %d :  %s", ex.code, ex.msg)
             if hasattr(ex, 'readlines'):
                 _log.debug("".join(ex.readlines()))
@@ -231,7 +230,7 @@ def main_delete(args=None, func=_print_page):
     try:
         page = delete_page(configFile, SECTION,
                            subresource='%s' % simulationName)
-    except HTTPError as ex:
+    except urllib.error.HTTPError as ex:
         _log.error(ex)
         raise
     _log.debug("PAGE: %s" % page)

--- a/turbine/commands/turbine_simulation_script.py
+++ b/turbine/commands/turbine_simulation_script.py
@@ -108,7 +108,7 @@ def main_update(args=None):
     if len(args) != 3:
         op.error('expecting 3 arguments')
 
-    _log.debug(args)
+    _log.debug('main_update: %s' %args)
 
     file_name = args[1]
     if not os.path.isfile(file_name):


### PR DESCRIPTION
Added supported for signed URLs for the simulation resource on the AWS FOQUS Cloud.  Specifying "SignedUrl" will cause the client to utilize signed URLs on AWS S3 to get/put documents.

```
[Simulation]
url = https://b7x9ucxadg.execute-api.us-east-1.amazonaws.com/development/simulation
SignedUrl = True
[Session]
url = https://b7x9ucxadg.execute-api.us-east-1.amazonaws.com/development/session
[Job]
url = https://b7x9ucxadg.execute-api.us-east-1.amazonaws.com/development/job
[Application]
url = https://b7x9ucxadg.execute-api.us-east-1.amazonaws.com/development/application
[Consumer]
url =
[Authentication]
username = ****
password = ****
[Logging]
fileConfig = logging.conf
```
